### PR TITLE
Remove the word "capstone" and restructure the overview

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ Please look at [README.md](README.md) instead. :green_heart: :blue_heart:
 {:style="text-align: left;"}
 
 {:style="width: 100%;"}
-* [Snowflakes](https://github.com/ClojureBridge/drawing/blob/master/curriculum/create-something.md) (animation)
+* [Snowflakes](https://github.com/ClojureBridge/drawing/blob/master/curriculum/create-something.md) Animation
 * [Land of Quil](http://landofquil.we-do-fp.berlin/) Several Quil examples you can try out
 
 &nbsp;
@@ -57,8 +57,8 @@ Please look at [README.md](README.md) instead. :green_heart: :blue_heart:
 
 {:style="width: 100%;"}
 * [Twinkle Twinkle Little Star](https://github.com/ClojureBridge/tones/blob/master/curriculum/01-piano-chords.md) Making sounds with Overtone
-* [Global Growth](https://github.com/ClojureBridge/global-growth)  (web app with REST api)
-* [Caesar Cipher](http://clojurebridge.github.io/community-docs/docs/exercises/caesar-cipher/) (mini exercise of Strings and Characters)
-* [Turtles Walk](https://github.com/ClojureBridge/welcometoclojurebridge/blob/master/outline/TURTLE-SAMPLES.md) (more function study)
+* [Global Growth](https://github.com/ClojureBridge/global-growth) Web app with REST api
+* [Caesar Cipher](http://clojurebridge.github.io/community-docs/docs/exercises/caesar-cipher/) Mini exercise of Strings and Characters
+* [Turtles Walk](https://github.com/ClojureBridge/welcometoclojurebridge/blob/master/outline/TURTLE-SAMPLES.md) More function study
 
 </section>

--- a/index.md
+++ b/index.md
@@ -28,22 +28,37 @@ Please look at [README.md](README.md) instead. :green_heart: :blue_heart:
 
 {% endcomment %}
 
+### Part I: Basics
+
 * [Introduction to Programming with Clojure](outline/intro.html)
 * [Simple Values](outline/simple_values.html)
 * [Data Structures](outline/data_structures.html)
 * [Functions](outline/functions.html)
-* [Capstone App: Drawing Lines](https://github.com/clojurebridge-berlin/drawing/blob/master/curriculum/first-program.md)
+* [Your First Program: Drawing Lines](https://github.com/clojurebridge-berlin/drawing/blob/master/curriculum/first-program.md)
 * [Flow Control and Logic](outline/flow_control.html)
 * [[bonus module] Sequences](outline/sequences.html)
 
-* Choices of Capstone App - Part. 2
+</section>
 
-    - [Turtles Walk](https://github.com/ClojureBridge/welcometoclojurebridge/blob/master/outline/TURTLE-SAMPLES.md) (more function study)
+<section>
+### Part II: Practical Applications
 
-    - [Snowflakes](https://github.com/ClojureBridge/drawing/blob/master/curriculum/create-something.md) (animation)
+#### Graphics with Quil
+{:style="text-align: left;"}
 
-    - [Twinkle Twinkle Little Star](https://github.com/ClojureBridge/tones/blob/master/curriculum/01-piano-chords.md) (making sounds)
-    - [Global Growth](https://github.com/ClojureBridge/global-growth)  (web app with REST api)
-    - [Caesar Cipher](http://clojurebridge.github.io/community-docs/docs/exercises/caesar-cipher/)
-          (mini exercise of Strings and Characters)
+{:style="width: 100%;"}
+* [Snowflakes](https://github.com/ClojureBridge/drawing/blob/master/curriculum/create-something.md) (animation)
+* [Land of Quil](http://landofquil.we-do-fp.berlin/) Several Quil examples you can try out
+
+&nbsp;
+
+#### Other applications
+{:style="text-align: left;"}
+
+{:style="width: 100%;"}
+* [Twinkle Twinkle Little Star](https://github.com/ClojureBridge/tones/blob/master/curriculum/01-piano-chords.md) Making sounds with Overtone
+* [Global Growth](https://github.com/ClojureBridge/global-growth)  (web app with REST api)
+* [Caesar Cipher](http://clojurebridge.github.io/community-docs/docs/exercises/caesar-cipher/) (mini exercise of Strings and Characters)
+* [Turtles Walk](https://github.com/ClojureBridge/welcometoclojurebridge/blob/master/outline/TURTLE-SAMPLES.md) (more function study)
+
 </section>


### PR DESCRIPTION
![2016-01-21-190753_786x517_scrot](https://cloud.githubusercontent.com/assets/32212/12489785/5376f0f8-c072-11e5-970d-5a06299bff11.png)
![2016-01-21-190803_996x576_scrot](https://cloud.githubusercontent.com/assets/32212/12489786/5378da08-c072-11e5-9d88-5c7b3513baf7.png)

Split the overview into two slides, the first section is the basic
curriculum, the second is a choice of applications to try out, beginning
with Quil.
