### PR TITLE
Remove turtle references and some rephrasing

### DIFF
--- a/outline/data_structures.md
+++ b/outline/data_structures.md
@@ -84,31 +84,17 @@ collections together.
 </section>
 
 <section ng-controller="NarrativeController">
-#### Example <button class="link" ng-bind-html="details" ng-model="block41" ng-click="block41=!block41"></button>
-
-> When there are a couple of turtles,
-> `(turtle-names)` command will return turtle names in the form of a
-> vector.
-{: ng-show="block41" .description}
-
-```clojure
-(turtle-names)
-;=> [:trinity :neo :oracle :cypher]
-```
-</section>
-
-
-<section ng-controller="NarrativeController">
 #### Creation <button class="link" ng-bind-html="details" ng-model="block61" ng-click="block61=!block61"></button>
 
-> The next two functions are used to make new vectors. The `vector`
-> function takes any number of items and puts them in a new vector.
-> `conj` is an interesting function that you'll see used with all the
-> data structures. With vectors, it takes a vector and an item and
-> returns a new vector with that item added to the end of the vector.
-> Why the name `conj`? `conj` is short for conjoin, which means to 
-> join or combine. This is what we're doing: we're joining the new
-> item to the vector.
+> Instead of writing a vector with square brackets, you can also use the vector
+> function to create a vector. All arguments are collected and placed inside a new
+> vector.
+>
+> `conj` takes a vector and some other values, and returns a new vector with the
+> extra value added. `conj` is short for conjoin, which means to join or combine.
+> This is what we're doing: we're joining the extra value to the vector. `conj`
+> can be used with any kind of collection. Right now the only kind of
+> collection we've encountered is a vector.
 {: ng-show="block61" .description}
 
 ```clojure
@@ -146,20 +132,10 @@ be confusing.
 </section>
 
 <section>
-#### EXERCISE 1: See turtle names
+#### EXERCISE: Make a vector
 {: .slide_title .slide}
 
-* Go to `walk.clj` file
-* Type `(add-turtle :neo)` and evaluate this line by hitting hit <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>x</kbd> or <kbd>cmd</kbd> <kbd>shift</kbd> + <kbd>x</kbd>
-* Repeat adding turtles a couple of times with different names
-* Type `(turtle-names)`, evaluate this line and see the result
-</section>
-
-<section>
-#### EXERCISE 2: Make a vector
-{: .slide_title .slide}
-
-* Go to insta-REPL
+* Go to your REPL
 * Make a vector of the high temperatures for the next 7 days in the
   town where you live.
 * Then use the `nth` function to get the high temperature for next
@@ -200,21 +176,6 @@ be confusing.
 {:first "Sally" :last "Brown"}
 {:a 1 :b "two"}
 {}
-```
-</section>
-
-<section ng-controller="NarrativeController">
-#### Example <button class="link" ng-bind-html="details" ng-model="block103" ng-click="block103=!block103"></button>
-
-> When turtle received commands such that `forward` or `right`,
-> those return the result as a form of map of map.
-{: ng-show="block103" .description}
-
-```clojure
-(forward 40)
-;=> {:trinity {:length 40}}
-(right 90)
-;=> {:trinity {:angle 90}}
 ```
 </section>
 
@@ -326,70 +287,28 @@ be confusing.
 #### Vector of Maps
 
 ```clojure
-(state-all)
-;=> [{:trinity {:x -1.7484556000744965E-6, :y 39.99999999999996, :angle 90, :color [106 40 126]}}
-{:neo {:x 21.213202971967114, :y 21.213203899225725, :angle 45, :color [0 64 0]}}
-{:oracle {:x -49.99999999999981, :y -4.3711390001862375E-6, :angle 180, :color [43 101 236]}}]
+(def characters
+  [{:name "Snoopy"
+    :species "dog"}
+   {:name "Woodstock"
+    :species "bird"}
+   {:name "Charlie Brown"
+    :species "human"}])
 
-(def states (state-all))
-;=> #'clojurebridge-turtle.walk/states
+(:name (first characters))
+;;=> "Snoopy"
 
-(first states)
-;=> {:trinity {:x -1.7484556000744965E-6, :y 39.99999999999996,
-:angle 90, :color [106 40 126]}}
-```
-</section>
-
-<section>
-#### Map of Maps
-
-```clojure
-(def st (first states))
-;=> #'clojurebridge-turtle.walk/st
-
-st
-;=> {:trinity {:x -1.7484556000744965E-6, :y 39.99999999999996, :angle
-90, :color [30 30 30]}}
-
-(:trinity st)
-;=> {:x -1.7484556000744965E-6, :y 39.99999999999996, :angle 90, :color [30 30 30]}
-
-(get-in st [:trinity :angle])
-;=> 90
+(map :name characters)
+;;=> ("Snoopy" "Woodstock" "Charlie Brown")
 ```
 </section>
 
 
 <section>
-#### EXERCISE 3: See turtles states
+#### EXERCISE: Modeling Yourself
 {: .slide_title .slide}
 
-* Go to `walk.clj` file
-* Click "Run with REPL" or type <kbd>ctrl</kbd>/<kbd>cmd</kbd> + <kbd>e</kbd>
-* Try examples of previous two slides
-* See what values you get
-
-> Every time you write a line of code,
-> hit <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>x</kbd> or 
-> <kbd>cmd</kbd> <kbd>shift</kbd> + <kbd>x</kbd>
-> to evaluate it one by one.
-
-```clojure
-(state-all)
-(def states (state-all))
-(first states)
-(def st (first states))
-st
-(:trinity st)
-(get-in st [:trinity :angle])
-```
-</section>
-
-<section>
-#### EXERCISE 4: Modeling Yourself
-{: .slide_title .slide}
-
-* Using the Clojure REPL in the bottom left
+* Using the Clojure REPL
     - (Option) You may create a new file and write code in the file. To
     evaluate, select the code you want and hit <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>x</kbd> or <kbd>cmd</kbd> <kbd>shift</kbd> + <kbd>x</kbd>, or press the "Eval" button
 * Make a map representing yourself
@@ -398,7 +317,7 @@ st
 </section>
 
 <section>
-#### EXERCISE 5 [BONUS]: Modeling your classmates
+#### EXERCISE [BONUS]: Modeling your classmates
 {: .slide_title .slide}
 
 * First, take the map you made about yourself in previous exercise.

--- a/outline/intro.md
+++ b/outline/intro.md
@@ -113,8 +113,9 @@ Introduction to Programming with Clojure
 {: .slide_title .slide}
 
 ```clojure
-(print-str "Hello, World!")
 (+ 3 4)
+(max 8 17 2)
+(print-str "Hello, World!")
 ```
 
 #### Parentheses <button class="link" ng-bind-html="details" ng-model="block31" ng-click="block31=!block31"></button>
@@ -131,17 +132,19 @@ Introduction to Programming with Clojure
 > Next to the parentheses, we see the instructions to the
 > computer. That instruction is normally what we call a _function_.
 > The functions do all the hard work in Clojure.
-> `print-str` and `+` are functions.
+> `+`, `max`, and `print-str` are all functions.
 > When these functions get run, they return a some type of value.
 > Clojure functions always return a value.
 {: ng-show="block32" .description}
 
 #### Arguments <button class="link" ng-bind-html="details" ng-model="block33" ng-click="block33=!block33"></button>
 
-> Many functions take in _arguments_--which are everything else inside
-> the enclosing parentheses after the function--.
-> `print-str` takes "Hello, World!" and returns a string.
-> `+` takes 3 and 4, adds them, and returns 7.
+> Many functions take in _arguments_ (everything else inside
+> the enclosing parentheses function).
+>
+> * `+` takes 3 and 4, adds them, and returns 7.
+> * `max` takes 8, 17, and 2, and returns the highest: 17.
+> * `print-str` takes "Hello, World!" and prints it out.
 {: ng-show="block33" .description}
 </section>
 
@@ -172,8 +175,9 @@ Introduction to Programming with Clojure
 
 ```clojure
 ;; example functions from a previous slide
-(print-str "Hello, World!")  ; a well-known hello world
 (+ 3 4)                      ; why not 3 + 4? figure out later
+(max 8 17 2)                 ; there's a min too
+(print-str "Hello, World!")  ; a well-known hello world
 ```
 </section>
 

--- a/outline/intro.md
+++ b/outline/intro.md
@@ -115,7 +115,6 @@ Introduction to Programming with Clojure
 ```clojure
 (print-str "Hello, World!")
 (+ 3 4)
-(forward :trinity 40)
 ```
 
 #### Parentheses <button class="link" ng-bind-html="details" ng-model="block31" ng-click="block31=!block31"></button>
@@ -132,7 +131,7 @@ Introduction to Programming with Clojure
 > Next to the parentheses, we see the instructions to the
 > computer. That instruction is normally what we call a _function_.
 > The functions do all the hard work in Clojure.
-> `print-str`, `+` and `forward` are all functions.
+> `print-str` and `+` are functions.
 > When these functions get run, they return a some type of value.
 > Clojure functions always return a value.
 {: ng-show="block32" .description}

--- a/outline/intro.md
+++ b/outline/intro.md
@@ -143,8 +143,6 @@ Introduction to Programming with Clojure
 > the enclosing parentheses after the function--.
 > `print-str` takes "Hello, World!" and returns a string.
 > `+` takes 3 and 4, adds them, and returns 7.
-> `forward` takes :trinity and 40, moves a turtle by 40 and returns
-> the result.
 {: ng-show="block33" .description}
 </section>
 
@@ -215,7 +213,7 @@ Introduction to Programming with Clojure
 
 > There's a couple of ways to get to a REPL in Nightcode. One general one
 > that is always running in the corner of the window, and another that is
-> launched with the "Run with REPL". 
+> launched with the "Run with REPL".
 {: ng-show="block62" .description}
 
 > The easiest REPL to access and use is loaded from the beginning of
@@ -233,15 +231,15 @@ Introduction to Programming with Clojure
 > pane. The first time you run this, it'll take a little while.
 {: ng-show="block63" .description}
 
-> After this, you'll find a new REPL launch in that bottom pane. Here you 
+> After this, you'll find a new REPL launch in that bottom pane. Here you
 > can type commands just like the other REPL -- but now you can also type
-> code in the main file, and run it with the `Eval` button 
+> code in the main file, and run it with the `Eval` button
 > (<kbd>ctrl</kbd>/<kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>x</kbd>, making sure the cursor is next to the code).
 {: ng-show="block63" .description}
 </section>
 
 <section>
-#### EXERCISE 1: Try the Clojure REPL
+#### EXERCISE: Try the Clojure REPL
 
 * Start Nightcode
 * Focus on the REPL in the bottom left
@@ -261,24 +259,20 @@ Introduction to Programming with Clojure
 <section>
 #### EXERCISE 2: Evaluate file and line
 
-<!-- TODO change the example here away from turtles -->
-* Open the file `welcometoclojurebridge/src/clojurebridge_turtle/walk.clj`
-* Evaluate the entire file by hitting <kbd>cmd</kbd> + <kbd>e</kbd> or <kbd>ctrl</kbd> +
-  <kbd>e</kbd> and see what happens
-* Type `(forward 40)` and evaluate this line by hitting <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>x</kbd> or <kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>x</kbd>
+* In NightCode, at the top left, click on "New Project"
+* Choose a location and a name
+* Click on "Graphics" (the button with a big "Q" on it)
+* Click on "Run with REPL", a window will pop up with a grey circle
+* Find the line `(fill 192)` and change it to `(fill 250 20 20)`
+* With your cursor on that line click on `Eval` (<kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>x</kbd> or <kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>x</kbd>)
 * See what happens
-* Type `(right 90)` or other commands and evaluate the lines one by
-  one by hitting <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>x</kbd> or <kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>x</kbd>
-* Take a look [Turtles App API](https://github.com/ClojureBridge/welcometoclojurebridge/blob/master/outline/TURTLE.md) and
-[How To Walk Turtles](https://github.com/ClojureBridge/welcometoclojurebridge/blob/master/outline/TURTLE-SAMPLES.md)
-[section 1 and 2], and try more commands to walk your turtle
 </section>
 
 <section>
 #### EXERCISE 3: Look at Clojure docs
 
 * In the REPL, try to look up the documentation for a function you have used
-* You can use the `(doc function-name)` command to do this. For instance, try typing `(doc first)` into the REPL
+* You can use the `(doc function-name)` command to do this. For instance, try typing `(doc fill)` into the REPL
 * Now, make sure the "Doc" button at the top of window is selected (it'll be a lighter colour when selected)
 * In your Clojure file, start typing the name of a function
 * Before you even finish typing, the documentation for that function should appear


### PR DESCRIPTION
Remove turtle references from data_structures.md, use a simple example
with literals for "vector of maps".

This should get rid of the most surprising stuff. There is still a bunch of turtle stuff in the Sequences module, but that's bonus material so not sure how many will get there.
