### PR TITLE
Put docstring after function name in `defn` intro

### DIFF
--- a/outline/functions.md
+++ b/outline/functions.md
@@ -47,8 +47,8 @@ Functions
 
 ```clojure
 (defn add                        ; name
-  [x y]                          ; arguments
   "Adds together two numbers"    ; documentation
+  [x y]                          ; arguments
   (+ x y))                       ; body
 
 (add 1 2)         ;=> 3 


### PR DESCRIPTION
(see https://github.com/bbatsov/clojure-style-guide#docstring-after-fn-name)
