### PR TITLE
Update 'Eval' instructions for Nightcode

### DIFF
--- a/outline/01_intro.md
+++ b/outline/01_intro.md
@@ -238,8 +238,8 @@ Welcome to Programming!
 
 > After this, you'll find a new REPL launch in that bottom pane. Here you
 > can type commands just like the other REPL -- but now you can also type
-> code in the main file, and run it with the `Eval` button
-> (<kbd>ctrl</kbd>/<kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>x</kbd>, making sure the cursor is next to the code).
+> code in the main file, and run it with the `Reload Selection` button
+> (<kbd>ctrl</kbd>/<kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>r</kbd>), making sure the cursor is next to the code.
 {: ng-show="block63" .description}
 </section>
 
@@ -264,13 +264,15 @@ Welcome to Programming!
 <section>
 #### EXERCISE 2: Evaluate file and line
 
-* In NightCode, at the top left, click on "New Project"
+* In NightCode, at the top left, click on "Start"
+* Click on "Graphics project"
 * Choose a location and a name (nb: don't call it `quil`)
-* Click on "Graphics" (the button with a big "Q" on it)
-* Click on "Run with REPL", a window will pop up with a grey circle
-* Find the line `(fill 192)` and change it to `(fill 250 20 20)`
-* Select the code from lines 7 to 10 with your cursor (make sure all of it is selected) and click on `Eval Selection` (<kbd>ctrl</kbd> + <kbd>E</kbd> or <kbd>cmd</kbd> + <kbd>E</kbd>)
-* See what happens
+* Click on "Run with REPL", a window with a grey circle opens
+* Open the file `src/`(project_name)`/core.clj`
+* Find the line `(fill 192)` and change it to
+  `(fill 250 20 20)`
+* Set your cursor at the beginning of line 7 and click on `Reload Selection` (<kbd>ctrl</kbd>/<kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>r</kbd>)
+* See what happens in the window that popped up earlier
 </section>
 
 <section>

--- a/outline/03_data_structures.md
+++ b/outline/03_data_structures.md
@@ -312,7 +312,7 @@ be confusing.
 
 * Using the Clojure REPL
     - (Option) You may create a new file and write code in the file. To
-    evaluate, select the code you want and hit <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>x</kbd> or <kbd>cmd</kbd> <kbd>shift</kbd> + <kbd>x</kbd>, or press the "Eval" button
+    evaluate, set the cursor next to the code you want and hit <kbd>ctrl</kbd>/<kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>r</kbd>, or press the `Reload Selection` button
 * Make a map representing yourself
 * Make sure it contains your first name and last name
 * Then, add your hometown to the map using [assoc](http://grimoire.arrdem.com/1.6.0/clojure.core/assoc/) or [merge](http://grimoire.arrdem.com/1.6.0/clojure.core/merge/).

--- a/outline/04_functions.md
+++ b/outline/04_functions.md
@@ -58,7 +58,7 @@ Functions
 
 
 <section ng-controller="NarrativeController">
-### EXERCISE: Find per-person share of bill among a group
+### EXERCISE: Re-use a function
 {: .slide_title .slide}
 
 * Create a new function, `add-one`, that takes a single argument


### PR DESCRIPTION
Closes #30 

'Eval' has changed name to 'Reload Selection' as of 2.0.4
(https://github.com/oakes/Nightcode/releases/tag/2.0.4)
This updates the references i could find to use the new keyboard
shortcut and the new way to work with it (not selecting text but setting
the cursor at the right point).

I also updated the headline on one of the functions slides, it looked
like we had forgotten that on ee5aba62

These slides have changed:
**old** http://clojurebridge-berlin.org/curriculum/outline/intro.html#/6 (bottom detail section)
**new** http://karlwestin.github.io/curriculum/outline/intro.html#/6

**old** http://clojurebridge-berlin.org/curriculum/outline/intro.html#/8
**new** http://karlwestin.github.io/curriculum/outline/intro.html#/8

**old** http://clojurebridge-berlin.org/curriculum/outline/data_structures.html#/15
**new** http://karlwestin.github.io/curriculum/outline/data_structures.html#/15

**old** http://clojurebridge-berlin.org/curriculum/outline/functions.html#/3
**new** https://karlwestin.github.io/curriculum/outline/functions.html#/3

